### PR TITLE
Update to 6.1.0.2

### DIFF
--- a/template
+++ b/template
@@ -5,9 +5,9 @@
 # for the convenience of those that rather to stick to void-packages.
 
 pkgname=megasync
-version=5.15.0.1
+version=6.1.0.2
 revision=1
-_sdk_commit="784ad98a7d55536fa4b2c4d2cf22016a3e416663"
+_sdk_commit="63daa4d1be2944210b974e5f7006641cbd353b80"
 build_style=cmake
 configure_args="-DCMAKE_BUILD_TYPE:STRING='None'
  -DCMAKE_MODULE_PATH:PATH='${XBPS_BUILDDIR}/${pkgname}-${version}/src/MEGASync/mega/cmake/modules/packages'
@@ -33,15 +33,15 @@ homepage="https://mega.co.nz"
 changelog="https://github.com/meganz/MEGAsync/releases/tag/v${version}_Linux"
 distfiles="https://github.com/meganz/MEGAsync/archive/refs/tags/v${version}_Linux.tar.gz
  https://github.com/meganz/sdk/archive/${_sdk_commit}.tar.gz>mega-sdk-${_sdk_commit}.tar.gz
- https://raw.githubusercontent.com/meganz/sdk/${_sdk_commit}/.clang-format"
-checksum="2aa309ed268dee336f50c32724e0e6c20de043378e05c3ab68507690b4a5856c
- 878af1fce0ddb3190aaee1a19fdc8a9c941de587e1be2c82e52930766500cb7b
+ https://raw.githubusercontent.com/meganz/sdk/${_sdk_commit}/.clang-format>clang-format-${_sdk_commit}"
+checksum="@f6d1b45cf4f1523f897cb04963f16dd763012687743efdd45d8965d8e8e27217
+ @8cbc6c16a74d149739436aafc0044e64f53c8a4b29040962f63233371bba19e3
  0edced6d312b725485c57b93e666d9237aa692163210e215fc0dec99e0e74c7b"
 restricted=yes
 repository=nonfree
 CXXFLAGS="-DNDEBUG"
 
-skip_extraction="mega-sdk-${_sdk_commit}.tar.gz .clang-format"
+skip_extraction="mega-sdk-${_sdk_commit}.tar.gz clang-format-${_sdk_commit}"
 
 export CMAKE_GENERATOR="Unix Makefiles"
 
@@ -51,7 +51,8 @@ esac
 
 post_extract() {
 	vsrcextract -C src/MEGASync/mega "mega-sdk-${_sdk_commit}.tar.gz"
-	vsrccopy .clang-format .
+	vsrccopy "clang-format-${_sdk_commit}" .
+	mv "clang-format-${_sdk_commit}" .clang-format
 }
 
 post_install() {


### PR DESCRIPTION
Now .clang-format is stored appending its commit hash in order to avoid
xbps-src marking it as known distfile (which may make it not calculate
the checksum again).

Matches CereusLinuxProject/cereus-pkgs@4a0136b.